### PR TITLE
[판매자용] 메인화면 UI 구현, 상품 등록 해시태그 chip 기능 추가

### DIFF
--- a/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/MainActivity.kt
+++ b/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/MainActivity.kt
@@ -15,7 +15,7 @@ import kotlin.concurrent.thread
 
 class MainActivity : AppCompatActivity() {
     private lateinit var auth: FirebaseAuth
-    lateinit var loginSellerUid: String
+    var loginSellerUid: String = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/data/model/Product.kt
+++ b/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/data/model/Product.kt
@@ -12,7 +12,7 @@ data class Product(
     var sellerUid: String,
     var sizeList: List<Long>,
     var colorList: List<Long>,
-    var hashTag: String,
+    var hashTag: List<String>,
     var category: Category,
     var reviewList: List<Review>,
     var orderCount: Long,

--- a/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/ui/home/HomeFragment.kt
+++ b/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/ui/home/HomeFragment.kt
@@ -8,17 +8,21 @@ import android.view.ViewGroup
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.findNavController
+import androidx.navigation.fragment.findNavController
 import com.petpal.swimmer_seller.MainActivity
 import com.petpal.swimmer_seller.R
 import com.petpal.swimmer_seller.data.repository.ProductRepository
 import com.petpal.swimmer_seller.databinding.FragmentHomeBinding
 import com.petpal.swimmer_seller.ui.product.ProductViewModel
 import com.petpal.swimmer_seller.ui.product.ProductViewModelFactory
+import com.petpal.swimmer_seller.ui.user.UserViewModel
+import com.petpal.swimmer_seller.ui.user.UserViewModelFactory
 
 class HomeFragment : Fragment() {
     lateinit var fragmentHomeBinding: FragmentHomeBinding
     lateinit var mainActivity: MainActivity
 
+    private lateinit var userViewModel: UserViewModel
     lateinit var homeViewModel: HomeViewModel
 
     override fun onCreateView(
@@ -30,6 +34,8 @@ class HomeFragment : Fragment() {
 
         val factory = HomeViewModelFactory(ProductRepository())
         homeViewModel = ViewModelProvider(this, factory)[HomeViewModel::class.java]
+
+        userViewModel = ViewModelProvider(this, UserViewModelFactory())[UserViewModel::class.java]
 
         homeViewModel.run {
             productCount.observe(mainActivity){
@@ -46,6 +52,13 @@ class HomeFragment : Fragment() {
             buttonRegProduct.setOnClickListener {
                 // 상품 등록화면으로 이동
                 it.findNavController().navigate(R.id.action_item_home_to_item_product_add)
+            }
+
+            buttonLogout.setOnClickListener {
+                userViewModel.logOut()
+                //메인 프래그먼트는 제거하고 로그인 프래그먼트로 이동
+                findNavController().popBackStack(R.id.mainFragment, true)
+                findNavController().navigate(R.id.loginFragment)
             }
         }
 

--- a/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/ui/home/HomeFragment.kt
+++ b/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/ui/home/HomeFragment.kt
@@ -63,7 +63,7 @@ class HomeFragment : Fragment() {
         }
 
         // 로그인한 판매자가 등록한 상품 개수 가져오기
-         homeViewModel.getProductCount(mainActivity.loginSellerUid)
+        homeViewModel.getProductCount(mainActivity.loginSellerUid)
 
         return fragmentHomeBinding.root
     }

--- a/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/ui/main/MainFragment.kt
+++ b/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/ui/main/MainFragment.kt
@@ -29,7 +29,7 @@ class MainFragment : Fragment() {
         val navController = navHostFragment.navController
 
         // 특정 화면에서 BottomNavigationBar 숨기기
-        navController.addOnDestinationChangedListener { navController: NavController, navDestination: NavDestination, bundle: Bundle? ->
+        navController.addOnDestinationChangedListener { _: NavController, navDestination: NavDestination, _: Bundle? ->
             if (navDestination.id == R.id.item_product_add) {
                 fragmentMainBinding.bottomNavigation.visibility = View.GONE
             } else {

--- a/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/ui/main/MainFragment.kt
+++ b/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/ui/main/MainFragment.kt
@@ -16,8 +16,7 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 
 class MainFragment : Fragment() {
-    private lateinit var userViewModel: UserViewModel
-    lateinit var fragmentMainBinding: FragmentMainBinding
+    private lateinit var fragmentMainBinding: FragmentMainBinding
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -26,20 +25,13 @@ class MainFragment : Fragment() {
         fragmentMainBinding = FragmentMainBinding.inflate(inflater)
 
         Log.d("user", "mainFragment onCreate")
-        userViewModel =
-            ViewModelProvider(this, UserViewModelFactory())[UserViewModel::class.java]
 
         // navigation
         val navHostFragment = childFragmentManager.findFragmentById(R.id.fragmentMainContainerView) as NavHostFragment
         val navController = navHostFragment.navController
 
         fragmentMainBinding.run {
-            button.setOnClickListener {
-                userViewModel.logOut()
-                //메인 프래그먼트는 제거하고 로그인 프래그먼트로 이동
-                findNavController().popBackStack(R.id.mainFragment, true)
-                findNavController().navigate(R.id.loginFragment)
-            }
+            // 로그아웃 기능은 일단 홈에 배치하고 나중에 DrawerLayout 메뉴에 넣기
 
             bottomNavigation.run {
                 setupWithNavController(navController)

--- a/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/ui/main/MainFragment.kt
+++ b/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/ui/main/MainFragment.kt
@@ -6,12 +6,10 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.lifecycle.ViewModelProvider
-import androidx.navigation.fragment.findNavController
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
 import com.petpal.swimmer_seller.R
 import com.petpal.swimmer_seller.databinding.FragmentMainBinding
-import com.petpal.swimmer_seller.ui.user.UserViewModel
-import com.petpal.swimmer_seller.ui.user.UserViewModelFactory
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 
@@ -30,8 +28,17 @@ class MainFragment : Fragment() {
         val navHostFragment = childFragmentManager.findFragmentById(R.id.fragmentMainContainerView) as NavHostFragment
         val navController = navHostFragment.navController
 
+        // 특정 화면에서 BottomNavigationBar 숨기기
+        navController.addOnDestinationChangedListener { navController: NavController, navDestination: NavDestination, bundle: Bundle? ->
+            if (navDestination.id == R.id.item_product_add) {
+                fragmentMainBinding.bottomNavigation.visibility = View.GONE
+            } else {
+                fragmentMainBinding.bottomNavigation.visibility = View.VISIBLE
+            }
+        }
+
         fragmentMainBinding.run {
-            // 로그아웃 기능은 일단 홈에 배치하고 나중에 DrawerLayout 메뉴에 넣기
+            // 로그아웃 버튼은 일단 Home 화면에 옮겨뒀습니다.
 
             bottomNavigation.run {
                 setupWithNavController(navController)

--- a/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/ui/product/ProductAddFragment.kt
+++ b/Swimmer_seller/app/src/main/java/com/petpal/swimmer_seller/ui/product/ProductAddFragment.kt
@@ -19,6 +19,7 @@ import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.chip.Chip
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.TextInputLayout
 import com.petpal.swimmer_seller.MainActivity
@@ -142,6 +143,15 @@ class ProductAddFragment : Fragment() {
                 validateEditText(it.toString(), textInputLayoutDescription, "상품 설명을 입력해 주세요")
             }
 
+            // 해시태그 추가
+            buttonAddHashTag.setOnClickListener {
+                val inputHashTagList = textInputEditTextHashTag.text.toString().split(",").map(String::trim)
+                for (inputHashTag in inputHashTagList) {
+
+
+                }
+            }
+
             // 대표 이미지 추가
             buttonAddMainImage.setOnClickListener {
                 val galleryIntent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI).apply {
@@ -203,6 +213,7 @@ class ProductAddFragment : Fragment() {
                 val code = System.currentTimeMillis().toString()
                 val mainImageFileName = "image/${code}_main_image.jpg"
                 val descriptionImageFileName = "image/${code}_description_image.jpg"
+                val hashTagList = textInputEditTextHashTag.text.toString().split(" ").map(String::trim)
 
                 val product = Product(
                     "",
@@ -215,7 +226,7 @@ class ProductAddFragment : Fragment() {
                     mainActivity.loginSellerUid,
                     mutableListOf<Long>(),
                     mutableListOf<Long>(),
-                    textInputEditTextHashTag.text.toString(),
+                    hashTagList,
                     category,
                     mutableListOf<Review>(),
                     0L,

--- a/Swimmer_seller/app/src/main/res/layout/fragment_home.xml
+++ b/Swimmer_seller/app/src/main/res/layout/fragment_home.xml
@@ -57,9 +57,10 @@
                         android:padding="15dp">
 
                         <TextView
-                            android:id="@+id/textView12"
+                            android:id="@+id/textViewCountPayment"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
+                            android:clickable="true"
                             android:gravity="center"
                             android:text="5"
                             android:textAppearance="@style/TextAppearance.AppCompat.Large"
@@ -94,9 +95,10 @@
                         android:padding="15dp">
 
                         <TextView
-                            android:id="@+id/textView17"
+                            android:id="@+id/textViewCountReady"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
+                            android:clickable="true"
                             android:gravity="center"
                             android:text="5"
                             android:textAppearance="@style/TextAppearance.AppCompat.Large"
@@ -129,9 +131,10 @@
                         android:padding="15dp">
 
                         <TextView
-                            android:id="@+id/textView16"
+                            android:id="@+id/textViewCountProcess"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
+                            android:clickable="true"
                             android:gravity="center"
                             android:text="5"
                             android:textAppearance="@style/TextAppearance.AppCompat.Large"
@@ -163,9 +166,10 @@
                         android:padding="15dp">
 
                         <TextView
-                            android:id="@+id/textView18"
+                            android:id="@+id/textViewCountComplete"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
+                            android:clickable="true"
                             android:gravity="center"
                             android:text="5"
                             android:textAppearance="@style/TextAppearance.AppCompat.Large"
@@ -207,11 +211,12 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_weight="1"
+                            android:clickable="true"
                             android:text="주문 취소"
                             android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
                         <TextView
-                            android:id="@+id/textView22"
+                            android:id="@+id/textViewCountCancel"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="5건"
@@ -230,11 +235,12 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_weight="1"
+                            android:clickable="true"
                             android:text="교환 신청"
                             android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
                         <TextView
-                            android:id="@+id/textView23"
+                            android:id="@+id/textViewCountChange"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="5건"
@@ -253,11 +259,12 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_weight="1"
+                            android:clickable="true"
                             android:text="환불 신청"
                             android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
                         <TextView
-                            android:id="@+id/textView24"
+                            android:id="@+id/textViewCountReturn"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="5건"
@@ -346,7 +353,7 @@
                         android:orientation="horizontal">
 
                         <ImageView
-                            android:id="@+id/imageView"
+                            android:id="@+id/imageViewGuide"
                             android:layout_width="200dp"
                             android:layout_height="match_parent"
                             android:layout_marginEnd="10dp"
@@ -361,14 +368,14 @@
                             android:orientation="vertical">
 
                             <TextView
-                                android:id="@+id/textView27"
+                                android:id="@+id/textViewGuideTitle"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
                                 android:text="쉽게 따라하는 상품 등록"
                                 android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 
                             <TextView
-                                android:id="@+id/textView26"
+                                android:id="@+id/textViewGuideContent"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
                                 android:text="SWIMMER Seller에 상품을 판매해보세요!"

--- a/Swimmer_seller/app/src/main/res/layout/fragment_home.xml
+++ b/Swimmer_seller/app/src/main/res/layout/fragment_home.xml
@@ -17,43 +17,380 @@
         app:title="SWIMMER Seller"
         app:titleTextColor="@color/white" />
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:padding="10dp">
+        android:layout_height="match_parent">
 
-        <TextView
-            android:id="@+id/textView"
-            style="@style/Widget.Material3.CheckedTextView"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/prompt_add_product_title"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+            android:orientation="vertical"
+            android:padding="15dp">
 
-        <TextView
-            android:id="@+id/textViewProductCount"
-            style="@style/Widget.Material3.CheckedTextView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:text="@string/prompt_product_count"
-            android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+            <TextView
+                android:id="@+id/textView2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="주문/배송"
+                android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                android:textStyle="bold" />
 
-        <TextView
-            android:id="@+id/textView3"
-            style="@style/Widget.Material3.CheckedTextView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/prompt_add_product"
-            android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:orientation="horizontal">
 
-        <view
-            android:id="@+id/buttonRegProduct"
-            class="com.google.android.material.button.MaterialButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:text="@string/action_add_product" />
-    </LinearLayout>
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardViewPayment"
+                    style="@style/Widget.Material3.CardView.Elevated"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="10dp"
+                    android:layout_weight="1">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:orientation="vertical"
+                        android:padding="15dp">
+
+                        <TextView
+                            android:id="@+id/textView12"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="center"
+                            android:text="5"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                            android:textColor="@color/md_theme_dark_inversePrimary"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:id="@+id/textView11"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="center"
+                            android:text="결제완료"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+                    </LinearLayout>
+
+                </com.google.android.material.card.MaterialCardView>
+
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardViewReady"
+                    style="@style/Widget.Material3.CardView.Elevated"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="10dp"
+                    android:layout_weight="1">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:orientation="vertical"
+                        android:padding="15dp">
+
+                        <TextView
+                            android:id="@+id/textView17"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="center"
+                            android:text="5"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                            android:textColor="@color/md_theme_dark_inversePrimary"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:id="@+id/textView13"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="center"
+                            android:text="배송대기"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardViewProgress"
+                    style="@style/Widget.Material3.CardView.Elevated"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="10dp"
+                    android:layout_weight="1">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:orientation="vertical"
+                        android:padding="15dp">
+
+                        <TextView
+                            android:id="@+id/textView16"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="center"
+                            android:text="5"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                            android:textColor="@color/md_theme_dark_inversePrimary"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:id="@+id/textView14"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="center"
+                            android:text="배송중"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/cardViewComplete"
+                    style="@style/Widget.Material3.CardView.Elevated"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:orientation="vertical"
+                        android:padding="15dp">
+
+                        <TextView
+                            android:id="@+id/textView18"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="center"
+                            android:text="5"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                            android:textColor="@color/md_theme_dark_inversePrimary"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:id="@+id/textView15"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="center"
+                            android:text="배송완료"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+            </LinearLayout>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardViewCancelChangeReturn"
+                style="@style/Widget.Material3.CardView.Elevated"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    android:padding="15dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:orientation="horizontal">
+
+                        <TextView
+                            android:id="@+id/textView19"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="주문 취소"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+                        <TextView
+                            android:id="@+id/textView22"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="5건"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                            android:textColor="@color/md_theme_dark_inversePrimary"
+                            android:textStyle="bold" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:orientation="horizontal">
+
+                        <TextView
+                            android:id="@+id/textView20"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="교환 신청"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+                        <TextView
+                            android:id="@+id/textView23"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="5건"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                            android:textColor="@color/md_theme_dark_inversePrimary"
+                            android:textStyle="bold" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:orientation="horizontal">
+
+                        <TextView
+                            android:id="@+id/textView21"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="환불 신청"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+                        <TextView
+                            android:id="@+id/textView24"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="5건"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                            android:textColor="@color/md_theme_dark_inversePrimary"
+                            android:textStyle="bold" />
+                    </LinearLayout>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardViewAddProduct"
+                style="@style/Widget.Material3.CardView.Elevated"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    android:padding="15dp">
+
+                    <TextView
+                        android:id="@+id/textView"
+                        style="@style/Widget.Material3.CheckedTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/prompt_add_product_title"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/textViewProductCount"
+                        style="@style/Widget.Material3.CheckedTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="10dp"
+                        android:text="@string/prompt_product_count"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+
+                    <TextView
+                        android:id="@+id/textView3"
+                        style="@style/Widget.Material3.CheckedTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/prompt_add_product"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/buttonRegProduct"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="10dp"
+                        android:text="@string/action_add_product" />
+
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardViewGuide"
+                style="@style/Widget.Material3.CardView.Elevated"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    android:padding="15dp">
+
+                    <TextView
+                        android:id="@+id/textView25"
+                        style="@style/Widget.Material3.CheckedTextView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="판매자 가이드"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                        android:textStyle="bold" />
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_marginTop="10dp"
+                        android:orientation="horizontal">
+
+                        <ImageView
+                            android:id="@+id/imageView"
+                            android:layout_width="200dp"
+                            android:layout_height="match_parent"
+                            android:layout_marginEnd="10dp"
+                            android:layout_weight="1"
+                            android:adjustViewBounds="true"
+                            android:src="@mipmap/ic_launcher" />
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:id="@+id/textView27"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="쉽게 따라하는 상품 등록"
+                                android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+                            <TextView
+                                android:id="@+id/textView26"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="SWIMMER Seller에 상품을 판매해보세요!"
+                                android:textAppearance="@style/TextAppearance.AppCompat.Small" />
+                        </LinearLayout>
+                    </LinearLayout>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.divider.MaterialDivider
+                android:id="@+id/divider"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonLogout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="로그아웃" />
+        </LinearLayout>
+    </ScrollView>
+
 </LinearLayout>

--- a/Swimmer_seller/app/src/main/res/layout/fragment_main.xml
+++ b/Swimmer_seller/app/src/main/res/layout/fragment_main.xml
@@ -23,10 +23,4 @@
         android:layout_height="wrap_content"
         app:menu="@menu/bottom_navigation_menu" />
 
-    <Button
-        android:id="@+id/button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="로그아웃" />
-
 </LinearLayout>

--- a/Swimmer_seller/app/src/main/res/layout/fragment_main.xml
+++ b/Swimmer_seller/app/src/main/res/layout/fragment_main.xml
@@ -21,6 +21,10 @@
         android:id="@+id/bottomNavigation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:menu="@menu/bottom_navigation_menu" />
+        android:layout_gravity="bottom"
+        app:layout_insetEdge="bottom"
+        app:layout_behavior="com.google.android.material.behavior.HideBottomViewOnScrollBehavior"
+        app:menu="@menu/bottom_navigation_menu"
+        />
 
 </LinearLayout>

--- a/Swimmer_seller/app/src/main/res/layout/fragment_product_add.xml
+++ b/Swimmer_seller/app/src/main/res/layout/fragment_product_add.xml
@@ -186,16 +186,10 @@
 
             <com.google.android.material.chip.ChipGroup
                 android:id="@+id/chipGroupHashTag"
+                style="@style/Widget.Material3.ChipGroup"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1">
-
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chipHashTag"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1" />
-            </com.google.android.material.chip.ChipGroup>
+                android:layout_weight="1"/>
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/textInputLayoutPrice"

--- a/Swimmer_seller/app/src/main/res/layout/fragment_product_add.xml
+++ b/Swimmer_seller/app/src/main/res/layout/fragment_product_add.xml
@@ -5,7 +5,14 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context=".ui.product.ProductAddFragment" >
+    tools:context=".ui.product.ProductAddFragment">
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/progressBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="gone" />
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbarProductAdd"
@@ -19,17 +26,11 @@
         app:title="@string/prompt_add_product_title"
         app:titleTextColor="@color/white" />
 
-    <com.google.android.material.progressindicator.LinearProgressIndicator
-        android:id="@+id/progressBar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:indeterminate="true"
-        android:visibility="gone"/>
-
     <ScrollView
         android:id="@+id/scrollView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="0dp"
+        android:layout_weight="1">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -189,7 +190,7 @@
                 style="@style/Widget.Material3.ChipGroup"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"/>
+                android:layout_weight="1" />
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/textInputLayoutPrice"
@@ -216,7 +217,7 @@
                 android:hint="@string/prompt_product_description"
                 android:transitionGroup="true"
                 app:endIconMode="clear_text"
-                app:errorEnabled="false" >
+                app:errorEnabled="false">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/textInputEditTextDescription"
@@ -260,29 +261,6 @@
 
             </LinearLayout>
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="horizontal"
-                android:padding="10dp">
-
-                <Button
-                    android:id="@+id/buttonCancel"
-                    style="@style/Widget.Material3.Button.OutlinedButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="10dp"
-                    android:layout_weight="1"
-                    android:text="@string/action_cancel" />
-
-                <Button
-                    android:id="@+id/buttonOK"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/action_register" />
-            </LinearLayout>
-
             <!--
             <com.google.android.material.floatingactionbutton.FloatingActionButton
                 android:id="@+id/fabUp"
@@ -295,5 +273,30 @@
 
         </LinearLayout>
     </ScrollView>
+
+    <LinearLayout
+        android:id="@+id/layoutButtom"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="10dp">
+
+        <Button
+            android:id="@+id/buttonCancel"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="10dp"
+            android:layout_weight="1"
+            android:text="@string/action_cancel" />
+
+        <Button
+            android:id="@+id/buttonOK"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/action_register" />
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/Swimmer_seller/app/src/main/res/layout/fragment_product_add.xml
+++ b/Swimmer_seller/app/src/main/res/layout/fragment_product_add.xml
@@ -41,7 +41,8 @@
                 android:id="@+id/textViewMainImage"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/prompt_main_image" />
+                android:text="@string/prompt_main_image"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -144,22 +145,57 @@
                     app:simpleItems="@array/categorySub1_1" />
             </com.google.android.material.textfield.TextInputLayout>
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/textInputLayoutTag"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"
-                android:hint="@string/prompt_hashtag"
-                android:transitionGroup="true"
-                app:endIconMode="clear_text"
-                app:errorEnabled="false">
+                android:gravity="top"
+                android:orientation="horizontal">
 
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/text_input_edit_text_hash_tag"
-                    android:layout_width="match_parent"
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/textInputLayoutTag"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:inputType="text" />
-            </com.google.android.material.textfield.TextInputLayout>
+                    android:layout_marginEnd="10dp"
+                    android:layout_weight="1"
+                    android:hint="@string/prompt_hashtag"
+                    android:transitionGroup="true"
+                    app:endIconMode="clear_text"
+                    app:errorEnabled="false"
+                    app:helperText="@string/prompt_hashtag_helper"
+                    app:helperTextEnabled="true"
+                    app:helperTextTextColor="@color/md_theme_light_secondary">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/textInputEditTextHashTag"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Button
+                    android:id="@+id/buttonAddHashTag"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="65dp"
+                    android:text="추가"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                    app:cornerRadius="5dp" />
+
+            </LinearLayout>
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/chipGroupHashTag"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1">
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chipHashTag"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+            </com.google.android.material.chip.ChipGroup>
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/textInputLayoutPrice"
@@ -186,7 +222,7 @@
                 android:hint="@string/prompt_product_description"
                 android:transitionGroup="true"
                 app:endIconMode="clear_text"
-                app:errorEnabled="false">
+                app:errorEnabled="false" >
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/textInputEditTextDescription"
@@ -200,7 +236,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"
-                android:text="@string/prompt_description_image" />
+                android:text="@string/prompt_description_image"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small" />
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/Swimmer_seller/app/src/main/res/layout/layout_chip_input.xml
+++ b/Swimmer_seller/app/src/main/res/layout/layout_chip_input.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.chip.Chip xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/Widget.Material3.Chip.Input.Icon.Elevated"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:checkable="false"
+    app:closeIconEnabled="true">
+
+</com.google.android.material.chip.Chip>

--- a/Swimmer_seller/app/src/main/res/values/strings.xml
+++ b/Swimmer_seller/app/src/main/res/values/strings.xml
@@ -195,7 +195,7 @@
     <string name="prompt_category_main">대분류</string>
     <string name="prompt_category_mid">중분류</string>
     <string name="prompt_category_sub">소분류</string>
-    <string name="prompt_hashtag">#해시태그</string>
+    <string name="prompt_hashtag_helper">쉼표(,)로 구분, 최대 10개</string>
     <string name="prompt_price">가격</string>
     <string name="prompt_product_description">상품 설명</string>
     <string name="prompt_description_image">상품 설명 이미지 (1개)</string>
@@ -215,4 +215,5 @@
     <string name="flippers">오리발</string>
     <string name="bag">가방</string>
     <string name="water_toy">물놀이용품</string>
+    <string name="prompt_hashtag">해시태그</string>
 </resources>


### PR DESCRIPTION
## PR Type
어떤 것에 대한 PR인지?

<!-- 아래 괄호 사이"x"를 입력해서 체크할 수 있습니당. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (프로젝트 설정)
- [ ] Documentation content changes
- [ ] Other... 


## PR Checklist
PR하기 전에 아래 조건 충족했는지 확인!

- [x] 커밋 메세지 포맷에 맞게 작성했나요?
- [ ] (bug fixes / features의 경우) docs을 첨부/수정 했나요?


## 변경사항
- 판매자용 앱 메인화면 UI 구현 (데이터는 처리는 아직X)
- 상품 등록 해시태그 chip으로 입력 및 삭제 기능 구현
- 특정화면에서 BottomNavigationBar 숨기기
- 상품 등록화면 취소, 등록 버튼 스크롤과 상관없이 항상 보이기

## 스크린샷

### 태그 등록
![해시태그 칩 버튼2](https://github.com/APPSCHOOL2-Android/FinalProject-ShoppingMallService-team3/assets/86085387/e84999af-e5ac-4f1d-9dc3-2b304a9e3f49)

### 홈 화면
![image](https://github.com/APPSCHOOL2-Android/FinalProject-ShoppingMallService-team3/assets/86085387/3682888d-9acf-4403-810b-3690c9d2d7ea)

### 상품 등록 화면
![Screenshot_1692616307](https://github.com/APPSCHOOL2-Android/FinalProject-ShoppingMallService-team3/assets/86085387/bf345a00-33c9-4805-932c-f6191c3b7451)

## Issue number and link
#21 

## 리뷰어들에게 전할 말
- 홈 화면 구성요소는 전부 CardView 입니다.
- 해시태그 값은 파이어베이스에 List<String>으로 저장됩니다. TextInputLayout은 태그 입력을 돕기 위한 입력란일 뿐, 실제로 저장되는 건 Chip으로 생성된 태그 뿐입니다. Chip 아이디어가 큰 도움이 됐어요 감사합니다!

- addOnDestinationChangedListener() 메서드를 통해, navigation으로 이동시 특정 Fragment(화면)에서만 하단네비바를 숨기는 식으로 구현했습니다.
```
navController.addOnDestinationChangedListener { _: NavController, navDestination: NavDestination, _: Bundle? ->
    if (navDestination.id == R.id.item_product_add) {
        fragmentMainBinding.bottomNavigation.visibility = View.GONE
    } else {
        fragmentMainBinding.bottomNavigation.visibility = View.VISIBLE
    }
}
```
- 기능 구현을 우선으로 하느라 아직 기존 코드 스타일 개선은 많이 못 했습니다.. 다른 분들 코드 많이 보고 배워야겠어요.😂

## 비고

📌 앞으로 개발해야 할 판매자 앱 주요 기능
1. 브랜드 로고 이미지 저장
2. 메인화면 주문상태별 건수 표시하기 <- orders 테스트 데이터 필요
3. 등록한 상품 목록, 상세 조회 화면