### PR TITLE
refactor: 주문목록 -> 주문상세 객체 전달

### DIFF
--- a/Swimmer_customer/app/src/main/java/com/petpal/swimmer_customer/OrderDetailFragment.kt
+++ b/Swimmer_customer/app/src/main/java/com/petpal/swimmer_customer/OrderDetailFragment.kt
@@ -1,11 +1,14 @@
 package com.petpal.swimmer_customer
 
+import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.ViewModelProvider
+import com.petpal.swimmer_customer.data.model.Order
 import com.petpal.swimmer_customer.databinding.FragmentOrderDetailBinding
 import com.petpal.swimmer_customer.ui.order.OrderViewModel
 import com.petpal.swimmer_customer.ui.order.OrderViewModelFactory
@@ -17,7 +20,7 @@ class OrderDetailFragment : Fragment() {
     // This property is only valid between onCreateView and
     // onDestroyView.
     private val fragmentOrderDetailBinding get() = _fragmentOrderDetailBinding!!
-    private var orderIdx: Int = -1
+    private lateinit var order: Order
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -26,7 +29,11 @@ class OrderDetailFragment : Fragment() {
         _fragmentOrderDetailBinding = FragmentOrderDetailBinding.inflate(layoutInflater)
 
         //argument로 넘어온 order 받아오기
-        orderIdx = arguments?.getInt("orderIdx",-1)!!
+        order = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arguments?.getParcelable("order", Order::class.java)!!
+        }else {
+            arguments?.get("order") as Order
+        }
 
 
         return fragmentOrderDetailBinding.root
@@ -36,7 +43,8 @@ class OrderDetailFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         orderViewModel =
             ViewModelProvider(this, OrderViewModelFactory())[OrderViewModel::class.java]
-        orderViewModel.setOrderWithIdx(orderIdx)
+        Log.d("orderViewModel", orderViewModel.toString())
+        orderViewModel.setOrder(order)
 
         orderViewModel.run {
             order.observe(viewLifecycleOwner) {

--- a/Swimmer_customer/app/src/main/java/com/petpal/swimmer_customer/data/model/ItemsForCustomer.kt
+++ b/Swimmer_customer/app/src/main/java/com/petpal/swimmer_customer/data/model/ItemsForCustomer.kt
@@ -1,5 +1,9 @@
 package com.petpal.swimmer_customer.data.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class ItemsForCustomer (
     // String 으로 test 진행 후 static 처리로 long 타입 변환 예정
     val productUid: String, // 제품 uid
@@ -12,4 +16,4 @@ data class ItemsForCustomer (
     val quantity: Long, // 제품 수량 -> 상세 페이지에서 결정 후 전송
     val size: String, // 제품 사이즈 -> 상세 페이지에서 결정 후 전송
     val color: String, // 제품 색상 -> 상세 페이지에서 결정 후 전송
-)
+):Parcelable

--- a/Swimmer_customer/app/src/main/java/com/petpal/swimmer_customer/data/model/Order.kt
+++ b/Swimmer_customer/app/src/main/java/com/petpal/swimmer_customer/data/model/Order.kt
@@ -1,6 +1,10 @@
 package com.petpal.swimmer_customer.data.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
+
+@Parcelize
 data class Order(
     // 주문 완료 상태로 전송
     // Long -> String 변경
@@ -28,4 +32,4 @@ data class Order(
     var couponUid: String,
     var usePoint: Long,
     var userUid: String,
-)
+):Parcelable

--- a/Swimmer_customer/app/src/main/java/com/petpal/swimmer_customer/ui/order/OrderListFragment.kt
+++ b/Swimmer_customer/app/src/main/java/com/petpal/swimmer_customer/ui/order/OrderListFragment.kt
@@ -1,6 +1,7 @@
 package com.petpal.swimmer_customer.ui.order
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -31,6 +32,10 @@ class OrderListFragment : Fragment() {
         savedInstanceState: Bundle?,
     ): View? {
         _fragmentOrderListBinding = FragmentOrderListBinding.inflate(layoutInflater)
+        orderViewModel =
+            ViewModelProvider(this, OrderViewModelFactory())[OrderViewModel::class.java]
+        Log.d("orderViewMode", orderViewModel.toString())
+
         fragmentOrderListBinding.run {
             tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
 
@@ -78,8 +83,7 @@ class OrderListFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        orderViewModel =
-            ViewModelProvider(this, OrderViewModelFactory())[OrderViewModel::class.java]
+
 
         //이 판매자가 올린 상품에 대한 주문 목록만 세팅하기
         orderViewModel.getOrderByUserUid(
@@ -139,7 +143,9 @@ class OrderListFragment : Fragment() {
                 rowOrderBinding.root.setOnClickListener {
                     //해당 주문상세로 넘어가기
                     val bundle = Bundle()
-                    bundle.putInt("orderIdx", adapterPosition)
+                    bundle.putParcelable("order",
+                        orderViewModel.orderList.value?.get(adapterPosition)
+                    )
                     findNavController().navigate(R.id.action_orderListFragment_to_orderDetailFragment, bundle)
                 }
             }

--- a/Swimmer_customer/app/src/main/java/com/petpal/swimmer_customer/ui/order/OrderViewModel.kt
+++ b/Swimmer_customer/app/src/main/java/com/petpal/swimmer_customer/ui/order/OrderViewModel.kt
@@ -42,4 +42,8 @@ class OrderViewModel(private val orderRepository: OrderRepository) : ViewModel()
     fun setOrderWithIdx(orderIdx: Int){
         _order.postValue(orderList.value!![orderIdx])
     }
+
+    fun setOrder(order: Order){
+        _order.postValue(order)
+    }
 }

--- a/Swimmer_customer/app/src/main/res/navigation/fragment_nav_graph.xml
+++ b/Swimmer_customer/app/src/main/res/navigation/fragment_nav_graph.xml
@@ -291,9 +291,8 @@
         android:label="fragment_order_detail"
         tools:layout="@layout/fragment_order_detail" >
         <argument
-            android:name="orderIdx"
-            app:argType="integer"
-            android:defaultValue="-1" />
+            android:name="order"
+            app:argType="com.petpal.swimmer_customer.data.model.Order" />
     </fragment>
 
 </navigation>


### PR DESCRIPTION
## PR Type
어떤 것에 대한 PR인지?

<!-- 아래 괄호 사이"x"를 입력해서 체크할 수 있습니당. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (프로젝트 설정)
- [ ] Documentation content changes
- [ ] Other... 


## PR Checklist
PR하기 전에 아래 조건 충족했는지 확인!

- [x] 커밋 메세지 포맷에 맞게 작성했나요?
- [ ] (bug fixes / features의 경우) docs을 첨부/수정 했나요?


## 변경사항
- 주문목록이랑 주문상세랑 다른 ViewModel인스턴스를 써서 리스트가 비어있다는 에러가 계속 뜨길래 주문목록에서 주문상세로 order객체 전달하도록 수정했습니다....


## 스크린샷
<!-- 작동 화면의 캡쳐 이미지나 gif를 올려주세요!-->


## Issue number and link
<!-- issue 링크 해주면 됩니다~-->


## 리뷰어들에게 전할 말
- 시간나면 객체 직접 전달하지 않도록 수정하겠씁니다~


## 비고
- 다른 하고싶은 말?
